### PR TITLE
Added an example demonstrating 3 simultaneous git clones

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,6 +82,7 @@ name = "command_timeout"
 version = "0.1.2"
 dependencies = [
  "anyhow",
+ "futures",
  "libc",
  "nix",
  "tempfile",
@@ -106,6 +107,95 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "futures"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+
+[[package]]
+name = "futures-task"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+
+[[package]]
+name = "futures-util"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+]
 
 [[package]]
 name = "getrandom"
@@ -267,6 +357,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -384,6 +480,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "slab"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,10 @@ thiserror = "1.0"
 nix = { version = "0.29", features = ["signal", "process"] } # For killpg
 libc = "0.2" # For setpgid and signal constants
 
+
+futures = "0.3"
+
+
 # Dependencies also used by the example(s)
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] } # For logging setup
 tempfile = "3" # For creating temporary directories in examples/tests
@@ -40,3 +44,10 @@ name = "git_clone_kernel"
 path = "examples/git_clone_kernel.rs"
 # Example requires tokio runtime features if not enabled globally in [dependencies]
 # required-features = ["full"] # Uncomment if tokio features are restricted in [dependencies]
+
+# Declare the example binary target
+[[example]]
+name = "simultaneous_git_clone"
+path = "examples/simultaneous_git_clone.rs"
+# Example requires tokio runtime features if not enabled globally in [dependencies]
+# required-features = ["full"] # uncomment if tokio features are restricted in [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,15 +17,11 @@ tracing = "0.1"
 thiserror = "1.0"
 nix = { version = "0.29", features = ["signal", "process"] } # For killpg
 libc = "0.2" # For setpgid and signal constants
-
-
-futures = "0.3"
-
-
 # Dependencies also used by the example(s)
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] } # For logging setup
 tempfile = "3" # For creating temporary directories in examples/tests
 anyhow = "1.0" # For simple error handling in examples
+futures = "0.3" # For simulataneous_git_clone example
 # Dependency on the library itself (needed for building examples within the workspace)
 # This line might not be strictly necessary if cargo automatically detects it,
 # but explicitly listing it can sometimes help.

--- a/examples/simultaneous_git_clone.rs
+++ b/examples/simultaneous_git_clone.rs
@@ -1,0 +1,215 @@
+use anyhow::{Context, Result};
+use command_timeout::{run_command_with_timeout, CommandError, CommandOutput};
+use std::os::unix::process::ExitStatusExt;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::Duration;
+use tempfile::Builder;
+use tracing::{error, info, warn, Level};
+use tracing_subscriber::FmtSubscriber;
+
+// Define the Git repository URL
+const CCXR: &str = "https://github.com/CCExtractor/ccextractor.git";
+const SAMPLE_PLATFORM: &str = "https://github.com/CCExtractor/sample-platform.git";
+const FLUTTERGUI: &str = "https://github.com/CCExtractor/ccextractorfluttergui.git";
+
+// Run like this:
+// RUST_LOG=debug cargo run --example simultaneous_git_clone
+
+#[tokio::main]
+async fn main() -> Result<(), anyhow::Error> {
+    // Using anyhow for simple example error handling
+    // Initialize tracing subscriber
+    let subscriber = FmtSubscriber::builder()
+        .with_max_level(Level::INFO) // Default to INFO level
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env()) // Allow RUST_LOG override
+        .finish();
+    tracing::subscriber::set_global_default(subscriber)
+        .expect("Setting default tracing subscriber failed");
+
+    info!("Starting simultaneous git clone example...");
+
+    // --- Timeout Configuration ---
+    let repos = vec![
+        (
+            CCXR,
+            Duration::from_secs(10),
+            Duration::from_secs(300),
+            Duration::from_secs(60),
+        ),
+        (
+            SAMPLE_PLATFORM,
+            Duration::from_secs(15),
+            Duration::from_secs(600),
+            Duration::from_secs(120),
+        ),
+        (
+            FLUTTERGUI,
+            Duration::from_secs(20),
+            Duration::from_secs(900),
+            Duration::from_secs(180),
+        ),
+    ];
+    info!("Configured repositories and timeouts:");
+    // -----------------------------
+
+    //Print repos and their timeouts
+    for (url, min, max, activity) in &repos {
+        info!(
+            "Repo: '{}', Min Timeout: {:?}, Max Timeout: {:?}, Activity Timeout: {:?}",
+            url, min, max, activity
+        );
+    }
+
+    //Create a temp directories to clone into
+    let clone_futures = repos.iter().map(|(url, min, max, activity)| async {
+        let dir = Builder::new()
+            .prefix(&format!(
+                "clone_{}",
+                url.split('/').last().unwrap_or("repo")
+            ))
+            .tempdir()
+            .context("Failed to create temporary directory")?;
+
+        clone_repository(url, dir.path(), *min, *max, *activity).await
+    });
+
+    //join_all runs all 3 clones concurrently
+    let results = futures::future::join_all(clone_futures).await;
+
+    //log error if error
+    for result in results {
+        if let Err(e) = result {
+            error!("Clone operation failed: {:?}", e);
+        }
+    }
+
+    //log success if success
+    info!("All clone operations completed.");
+
+    Ok(())
+}
+
+// Prepare the git clone command
+async fn clone_repository(
+    repo_url: &str,
+    target_path: &Path,
+    min_timeout: Duration,
+    max_timeout: Duration,
+    activity_timeout: Duration,
+) -> Result<(), anyhow::Error> {
+    // Using anyhow for simple example error handling
+
+    //log clone initialization with timeouts
+    info!(
+        "Preparing to clone '{}' into directory '{}'",
+        repo_url,
+        target_path.display()
+    );
+    info!(
+        "Timeouts: min={:?}, max={:?}, activity={:?}",
+        min_timeout, max_timeout, activity_timeout
+    );
+
+    //build git clone command
+    let mut cmd = Command::new("git");
+    cmd.arg("clone")
+        .arg("--progress") // Explicitly ask for progress output on stderr
+        .arg(repo_url)
+        .arg(target_path); // Clone into the target path
+
+    // Run the command using the library function
+    let result = run_command_with_timeout(cmd, min_timeout, max_timeout, activity_timeout).await;
+
+    //error handling
+    match result {
+        Ok(output) => {
+            handle_command_output(output, repo_url, &target_path.to_path_buf());
+        }
+        Err(e) => {
+            // Log specific details first
+            match &e {
+                // Borrow e here to allow using it later
+                CommandError::Spawn(io_err) => error!("Failed to spawn git: {}", io_err),
+                CommandError::Io(io_err) => error!("IO error reading output: {}", io_err),
+                CommandError::Kill(io_err) => error!("Error sending kill signal: {}", io_err),
+                CommandError::Wait(io_err) => error!("Error waiting for command exit: {}", io_err),
+                // Use 'ref msg' to borrow the string instead of moving it
+                CommandError::InvalidTimeout(ref msg) => error!("Invalid timeout config: {}", msg),
+                CommandError::StdoutPipe => error!("Failed to get stdout pipe from command"),
+                CommandError::StderrPipe => error!("Failed to get stderr pipe from command"),
+            }
+            error!("Command execution failed."); // General failure message
+
+            // Print path even on error
+            warn!(
+                "Clone operation failed. Directory may be incomplete or empty: {}",
+                target_path.display()
+            );
+
+            // Now convert the original error (which is still valid) and return
+            return Err(e.into());
+        }
+    }
+
+    Ok(())
+}
+
+fn handle_command_output(output: CommandOutput, repo_url: &str, target_path: &PathBuf) {
+    info!("Finished cloning '{}'.", repo_url);
+    info!("Total Duration: {:?}", output.duration);
+    info!("Timed Out: {}", output.timed_out);
+
+    if let Some(status) = output.exit_status {
+        if status.success() {
+            info!("Exit Status: {} (Success)", status);
+        } else {
+            warn!("Exit Status: {} (Failure)", status);
+            if let Some(code) = status.code() {
+                warn!("Exit Code: {}", code);
+            }
+            // signal() is now available because ExitStatusExt is in scope
+            if let Some(signal) = status.signal() {
+                warn!("Terminated by Signal: {}", signal);
+            }
+        }
+    } else {
+        warn!("Exit Status: None (Killed by timeout, status unavailable?)");
+    }
+
+    info!("Stdout Length: {} bytes", output.stdout.len());
+    if !output.stdout.is_empty() {
+        // Print snippet or full output (be cautious with large output)
+        info!(
+            "Stdout (first 1KB):\n---\n{}...\n---",
+            String::from_utf8_lossy(&output.stdout.iter().take(1024).cloned().collect::<Vec<_>>())
+        );
+    }
+
+    info!("Stderr Length: {} bytes", output.stderr.len());
+    if !output.stderr.is_empty() {
+        // Git clone progress usually goes to stderr
+        warn!(
+            "Stderr (first 1KB):\n---\n{}...\n---",
+            String::from_utf8_lossy(&output.stderr.iter().take(1024).cloned().collect::<Vec<_>>())
+        );
+        // For full stderr: warn!("Stderr:\n{}", String::from_utf8_lossy(&output.stderr));
+    }
+
+    if output.exit_status.map_or(false, |s| s.success()) && !output.timed_out {
+        info!("---> Clone completed successfully for '{}'! <---", repo_url);
+    } else if output.timed_out {
+        error!("---> Clone FAILED due to timeout for '{}'! <---", repo_url);
+    } else {
+        error!(
+            "---> Clone FAILED with non-zero exit status for '{}'! <---",
+            repo_url
+        );
+    }
+
+    //log success with directory location for each clone
+    info!(
+        "Clone operation finished. Directory location: {}",
+        target_path.display()
+    );
+}


### PR DESCRIPTION
This example uses `futures::join_all` to demonstrate this program's capability to execute 3 commands simultaneously 
`let results = futures::future::join_all(clone_futures).await;`
If some clone fails, others continue and a summary is provided at last like this : 
<img width="1396" alt="Screenshot 2025-04-03 at 9 21 51 PM" src="https://github.com/user-attachments/assets/e1dcf6e2-0a95-4f5c-b963-cb39469894a0" />